### PR TITLE
PHP 8.1: fix deprecation warnings

### DIFF
--- a/src/filesonlyfilter.php
+++ b/src/filesonlyfilter.php
@@ -37,6 +37,8 @@
 
 namespace TheSeer\DirectoryScanner {
 
+    use ReturnTypeWillChange;
+
     /**
      * FilterIterator to accept on files from a directory iterator
      *
@@ -52,6 +54,7 @@ namespace TheSeer\DirectoryScanner {
          *
          * @return boolean
          */
+        #[ReturnTypeWillChange]
         public function accept() {
             switch($this->current()->getType()) {
                 case 'file': {

--- a/src/includeexcludefilter.php
+++ b/src/includeexcludefilter.php
@@ -37,6 +37,8 @@
 
 namespace TheSeer\DirectoryScanner {
 
+    use ReturnTypeWillChange;
+
     /**
      * FilterIterator to accept Items based on include/exclude conditions
      *
@@ -88,6 +90,7 @@ namespace TheSeer\DirectoryScanner {
          *
          * @return boolean
          */
+        #[ReturnTypeWillChange]
         public function accept() {
             $pathname = $this->current()->getPathname();
 

--- a/src/phpfilter.php
+++ b/src/phpfilter.php
@@ -37,6 +37,8 @@
 
 namespace TheSeer\DirectoryScanner {
 
+    use ReturnTypeWillChange;
+
     /**
      * FilterIterator to accept only php source files based on content
      *
@@ -52,6 +54,7 @@ namespace TheSeer\DirectoryScanner {
          *
          * @return boolean
          */
+        #[ReturnTypeWillChange]
         public function accept() {
             $finfo = new \finfo(FILEINFO_MIME);
             return strpos($finfo->file($this->current()->getPathname()), 'text/x-php') === 0;


### PR DESCRIPTION
Came across these:

```
    [phpab] PHP Deprecated:  Return type of TheSeer\DirectoryScanner\IncludeExcludeFilterIterator::accept() should either be compatible with FilterIterator::accept(): bool, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///home/runner/work/phpunit/phpunit/tools/phpab/vendor/theseer/directoryscanner/src/includeexcludefilter.php on line 91
    [phpab] PHP Deprecated:  Return type of TheSeer\DirectoryScanner\FilesOnlyFilterIterator::accept() should either be compatible with FilterIterator::accept(): bool, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///home/runner/work/phpunit/phpunit/tools/phpab/vendor/theseer/directoryscanner/src/filesonlyfilter.php on line 55
```

These type of deprecation notices relate to the [Return types for internal methods RFC](https://wiki.php.net/rfc/internal_method_return_types) in PHP 8.1.

Basically, as of PHP 8.1, these methods in classes which implement PHP native interfaces are expected to have a return type declared.
The return type can be the same as used in PHP itself or a more specific type. This complies with the Liskov principle of covariance, which allows the return type of a child overloaded method to be more specific than that of the parent.

As this package has a minimum PHP requirement of PHP 5.3 based on the `composer.json` file, the return type can not be added, so I've added the attribute instead.

While attributes are a PHP 8.0 feature only, due to the syntax choice for `#[]`, they will be ignored in PHP < 8 and can be safely added.